### PR TITLE
Making "npm run cypress open" work

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "cypress": "cypress",
     "see-cy-coverage": "open ./cypress-coverage/lcov-report/index.html",
     "start": "next start"
   },


### PR DESCRIPTION
The command `npm run cypress open` in the doc is not working.

This PR fixes it.
